### PR TITLE
Cafeteria link changes

### DIFF
--- a/public/resources/oftenlinks.json
+++ b/public/resources/oftenlinks.json
@@ -57,7 +57,7 @@
   "name": "Speisepläne der Mensen",
   "description": "Speisepläne des Studierendenwerk Hamburg",
   "keywords": [],
-  "url": "http://www.studierendenwerk-hamburg.de/studierendenwerk/de/essen/speiseplaene/"
+  "url": "https://www.studierendenwerk-hamburg.de/gastronomie/mensen-cafes-weiteres"
 }, {
   "name": "Speiseplan Mensa Berliner Tor",
   "description": "Speiseplan Studierendenwerk Mensa Berliner Tor",


### PR DESCRIPTION
The link to view all cafeteria chaged. The Studierendenwerk seems to have a new layout. The link to the Mensa Berliner Tor still works, though.